### PR TITLE
Add homepage menus section with configurable visibility

### DIFF
--- a/.pages.yml
+++ b/.pages.yml
@@ -4,6 +4,14 @@ media:
   path: src/images
   categories: [image]
 content:
+  - name: homepage
+    label: Homepage Settings
+    type: file
+    path: src/_data/homepage.json
+    fields:
+      - { name: show_products, type: boolean, label: Show Products Section, default: true }
+      - { name: show_menus, type: boolean, label: Show Menus Section, default: true }
+      - { name: show_news, type: boolean, label: Show News Section, default: true }
   - name: site
     label: Site Configuration
     type: file

--- a/src/_data/config.json
+++ b/src/_data/config.json
@@ -4,8 +4,6 @@
 	"map_embed_src": "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2371.5540438557828!2d-2.2794691244293137!3d53.530020972343095!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x487baf2a5dca4691%3A0x5a433474b4b1a56a!2sChobble!5e0!3m2!1snl!2snl!4v1754922246959!5m2!1snl!2snl",
 	"sticky_mobile_nav": true,
 	"horizontal_nav": true,
-	"homepage_products": true,
-	"homepage_news": true,
 	"template_repo_url": "https://git.chobble.com/chobble/chobble-client",
 	"chobble_link": "https://chobble.com/services/chobble-template/",
 	"stripe_publishable_key": null,

--- a/src/_data/homepage.json
+++ b/src/_data/homepage.json
@@ -1,0 +1,5 @@
+{
+	"show_products": true,
+	"show_menus": true,
+	"show_news": true
+}

--- a/src/_layouts/home.html
+++ b/src/_layouts/home.html
@@ -4,14 +4,21 @@ layout: base.html
 
 {{ content }}
 
-{%- if config.homepage_news and collections.news.size > 0 -%}
+{%- assign menus = collections.menu | sort: 'data.order' -%}
+{%- if homepage.show_menus and menus.size > 0 -%}
+  <hr />
+  {%- render_snippet "homepage-menus-header", "<h3>Our Menus</h3>" -%}
+  {% include "menus-list.html" %}
+{%- endif -%}
+
+{%- if homepage.show_news and collections.news.size > 0 -%}
   <hr />
   {%- render_snippet "homepage-news-header", "<h3>Latest Posts</h3>" -%}
   {% include "news-post-list.html", limit: 2 %}
 {%- endif -%}
 
 {%- assign categories = collections.categories | getFeaturedCategories -%}
-{%- if config.homepage_products and categories.size > 0 -%}
+{%- if homepage.show_products and categories.size > 0 -%}
   <hr>
   {%- render_snippet "homepage-categories-header", "<h3>Product Categories</h3>" -%}
   {%- include "categories-list.html" -%}


### PR DESCRIPTION
## Summary
- Introduces a new homepage menus section to display menu items
- Adds configuration options to control visibility of products, menus, and news on the homepage
- Updates homepage layout to conditionally render menus alongside products and news

## Changes

### Configuration
- Removed `homepage_products` and `homepage_news` flags from `config.json`
- Added new `homepage.json` data file with `show_products`, `show_menus`, and `show_news` flags for flexible homepage content control

### Homepage Layout
- Modified `home.html` layout to:
  - Render menus section if `show_menus` is true and menus exist
  - Render news section if `show_news` is true and news items exist
  - Render product categories if `show_products` is true and categories exist
- Sorted menus by their `order` attribute before rendering

## Test plan
- [x] Verify menus section appears on homepage when `show_menus` is enabled and menus are present
- [x] Confirm news and products sections respect their respective visibility flags
- [x] Check that menus are sorted correctly by order
- [x] Ensure no errors occur if any section is disabled or has no content

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5a6da7bb-0067-4e12-b0e3-3816cfd8f9b1