### PR TITLE
Add map embed support to event pages

### DIFF
--- a/src/_includes/map-embed.html
+++ b/src/_includes/map-embed.html
@@ -1,4 +1,5 @@
-{%- if config.map_embed_src and config.map_embed_src != "" -%}
+{%- assign embed_src = maps_embed_src | default: config.map_embed_src -%}
+{%- if embed_src and embed_src != "" -%}
   <div class="map-embed">
     <iframe
       credentialless
@@ -8,7 +9,7 @@
       sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
       allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"
       referrerpolicy="no-referrer"
-      src="{{ config.map_embed_src }}"
+      src="{{ embed_src }}"
     >
     </iframe>
   </div>

--- a/src/_layouts/item.html
+++ b/src/_layouts/item.html
@@ -73,6 +73,12 @@ layout: base.html
 
   {{ content }}
 
+  {%- if maps_embed_src and maps_embed_src != "" -%}
+    <hr>
+    <h2>Location</h2>
+    {% include "map-embed.html" %}
+  {%- endif -%}
+
   {%- if features -%}
     <hr>
     <h2>Features</h2>

--- a/src/events/friday-workshop.md
+++ b/src/events/friday-workshop.md
@@ -5,6 +5,7 @@ subtitle: Learn new skills every week
 meta_description: Weekly workshops every Friday at 2 PM
 recurring_date: Every Friday at 2 PM
 event_location: Main Workshop Space
+maps_embed_src: https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2371.5540438557828!2d-2.2794691244293137!3d53.530020972343095!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x487baf2a5dca4691%3A0x5a433474b4b1a56a!2sChobble!5e0!3m2!1snl!2snl!4v1754922246959!5m2!1snl!2snl
 ---
 
 Join us every Friday for hands-on workshops where you can learn new skills and techniques. Each week features a different topic and instructor.


### PR DESCRIPTION
## Summary
- Adds support for embedding maps in event pages using a configurable map embed source
- Updates event layout to display a map section if a map embed URL is provided
- Demonstrates usage by adding a map embed URL to the Friday Workshop event

## Changes

### Template Updates
- Modified `map-embed.html` include to use a flexible `maps_embed_src` variable falling back to the global config
- Updated `item.html` layout to conditionally render a "Location" section with the map embed if `maps_embed_src` is set

### Content Updates
- Added `maps_embed_src` field with a Google Maps embed URL to `friday-workshop.md` event file

## Test plan
- [x] Verify map iframe renders correctly on the Friday Workshop event page
- [x] Confirm map embed does not appear on pages without `maps_embed_src` set
- [x] Check that the map embed respects sandbox and security attributes as intended

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/df777f89-5879-43f5-ab7b-b4e15924da01