### PR TITLE
Refactor product metadata handling to ES modules

### DIFF
--- a/src/_lib/schema-helper.js
+++ b/src/_lib/schema-helper.js
@@ -86,7 +86,7 @@ function buildOrganizationMeta(data) {
 	return meta;
 }
 
-module.exports = {
+export {
 	buildImageUrl,
 	buildBaseMeta,
 	buildProductMeta,

--- a/src/products/products.11tydata.js
+++ b/src/products/products.11tydata.js
@@ -1,7 +1,0 @@
-const { buildProductMeta } = require('../_lib/schema-helper');
-
-module.exports = {
-  eleventyComputed: {
-    meta: data => buildProductMeta(data)
-  }
-};

--- a/src/products/products.11tydata.mjs
+++ b/src/products/products.11tydata.mjs
@@ -1,5 +1,6 @@
 import strings from "../_data/strings.js";
 import { normaliseSlug } from "../_lib/slug-utils.js";
+import { buildProductMeta } from "../_lib/schema-helper.js";
 
 export default {
 	eleventyComputed: {
@@ -12,5 +13,6 @@ export default {
 			const dir = strings.product_permalink_dir || "products";
 			return `${dir}/${data.page.fileSlug}/`;
 		},
+		meta: (data) => buildProductMeta(data),
 	},
 };


### PR DESCRIPTION
## Summary
- Refactors product metadata handling to use ES module syntax
- Removes CommonJS `products.11tydata.js` in favor of `products.11tydata.mjs`
- Updates schema-helper exports to named exports for better ES module compatibility

## Changes

### Schema Helper
- Changed `module.exports` to named exports for functions including `buildProductMeta`

### Products Data
- Deleted `products.11tydata.js` which used CommonJS
- Added `products.11tydata.mjs` using ES module syntax
- Imported `buildProductMeta` from schema-helper using ES module import
- Added `meta` property in `eleventyComputed` to use `buildProductMeta` function

## Test plan
- Verify that product metadata is correctly computed and included in the site build
- Ensure no runtime errors due to module import/export changes
- Confirm that product URLs and metadata behave as expected in the generated site

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1b40939d-175e-43d8-af7a-07131e1618f5