### PR TITLE
Add timezone option to iCal generator from config

### DIFF
--- a/src/_data/config.json
+++ b/src/_data/config.json
@@ -16,5 +16,6 @@
 		"gallery_thumb_widths": "240,480",
 		"gallery_image_widths": "900,1300",
 		"header_image_widths": "640,900,1300"
-	}
+	},
+	"timezone": "Europe/London"
 }

--- a/src/_lib/ical.mjs
+++ b/src/_lib/ical.mjs
@@ -1,5 +1,6 @@
 import ical from 'ical-generator';
 import site from '../_data/site.json' with { type: 'json' };
+import config from '../_data/config.json' with { type: 'json' };
 
 export function generateICalForEvent(event) {
   // Only generate iCal for one-off events (not recurring)
@@ -8,10 +9,11 @@ export function generateICalForEvent(event) {
   }
 
   const siteName = site.name;
+  const timezone = config.timezone || 'Europe/London';
   const calendar = ical({
     prodId: `//${siteName}//Event Calendar//EN`,
     name: siteName,
-    timezone: 'UTC'
+    timezone: timezone
   });
 
   const eventDate = new Date(event.data.event_date);


### PR DESCRIPTION
## Summary
- Adds a timezone configuration option to the iCal event generator
- Defaults to 'Europe/London' if no timezone is specified in config

## Changes

### Configuration
- Added `timezone` field to `src/_data/config.json` with default value `Europe/London`

### iCal Generator
- Updated `generateICalForEvent` function in `src/_lib/ical.mjs` to use the configured timezone
- Falls back to `Europe/London` if no timezone is set in config

## Test plan
- Verify that generated iCal events use the configured timezone
- Confirm default timezone is applied when config timezone is missing
- Check that iCal generation still works for one-off events without errors

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ecedf704-55a1-4951-90e3-5b5abf32e192