### PR TITLE
Add fallback logic for product gallery using header_image

### DIFF
--- a/src/products/products.11tydata.mjs
+++ b/src/products/products.11tydata.mjs
@@ -8,6 +8,15 @@ export default {
 			const categories = data.categories || [];
 			return categories.map(normaliseSlug);
 		},
+		gallery: (data) => {
+			if (data.gallery) {
+				return data.gallery;
+			}
+			if (data.header_image) {
+				return [data.header_image];
+			}
+			return undefined;
+		},
 		navigationParent: () => strings.product_name,
 		permalink: (data) => {
 			const dir = strings.product_permalink_dir || "products";


### PR DESCRIPTION
## Summary
- Enhances product data handling by providing a fallback for the `gallery` property
- If `gallery` is absent, uses the single `header_image` as a one-item gallery array
- Returns `undefined` if neither `gallery` nor `header_image` are available

## Changes

### Data Layer
- Updated `src/products/products.11tydata.mjs`:
  - Added a new `gallery` getter function
  - Getter returns `data.gallery` if defined
  - Falls back to an array containing `data.header_image` if `gallery` is missing but `header_image` exists
  - Returns `undefined` if both are missing

## Test plan
- [x] Verified that products with a `gallery` property use it as expected
- [x] Verified that products without `gallery` but with `header_image` use an array of the single image
- [x] Verified products without either property return `undefined` for `gallery`

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/915968fd-2cec-45a8-9b73-b8412a19337c