### PR TITLE
Only show 'Gallery' title if multiple images exist

### DIFF
--- a/src/_layouts/item.html
+++ b/src/_layouts/item.html
@@ -47,7 +47,9 @@ layout: base
 
 {%- if gallery and gallery.size > 0 -%}
   <div class="gallery">
-    <h2>Gallery</h2>
+    {%- if gallery.size > 1 -%}
+      <h2>Gallery</h2>
+    {%- endif -%}
     {% include "gallery.html" %}
   </div>
 {%- endif -%}


### PR DESCRIPTION
## Summary
- Adjusts gallery title display logic to show `<h2>Gallery</h2>` only when there are more than one image
- Improves UI clarity by omitting redundant 'Gallery' heading when a single image is present

## Changes

### Template Update
- Modified `src/_layouts/item.html`:
  - Replaced unconditional gallery title with a conditional that checks if `gallery.size > 1`
  - Ensures the gallery heading appears only when it adds value visually

## Test plan
- [x] Verify no gallery heading appears when there is exactly one image
- [x] Confirm gallery heading appears when there are two or more images
- [x] Check that gallery content (`gallery.html`) renders as expected regardless of heading
- [x] Test across multiple devices and screen sizes for consistent UI behavior

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f4e89646-1748-4e10-82f3-7ed000d0e26c