### PR TITLE
Add cache-busting filter to stylesheet links in Eleventy config

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,3 +1,4 @@
+import { configureCacheBuster } from "./src/_lib/cache-buster.js";
 import { configureCategories } from "./src/_lib/categories.js";
 import { configureFeed } from "./src/_lib/feed.js";
 import { configureFileUtils } from "./src/_lib/file-utils.js";
@@ -28,6 +29,7 @@ export default async function (eleventyConfig) {
 
 	// configureLayoutAliases(eleventyConfig);
 
+	configureCacheBuster(eleventyConfig);
 	configureCategories(eleventyConfig);
 	await configureFeed(eleventyConfig);
 	configureFileUtils(eleventyConfig);

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -7,15 +7,15 @@
   {%- endif -%}
 
   {%- if production and layout != "theme-editor.html" -%}
-    <link rel="stylesheet" href="/css/bundle.css" />
+    <link rel="stylesheet" href="{{ '/css/bundle.css' | cacheBust }}" />
   {%- else -%}
-    <link rel="stylesheet" href="/css/nav.css" />
-    <link rel="stylesheet" href="/css/style.css" />
+    <link rel="stylesheet" href="{{ '/css/nav.css' | cacheBust }}" />
+    <link rel="stylesheet" href="{{ '/css/style.css' | cacheBust }}" />
     {%- for file in scssFiles -%}
-      <link rel="stylesheet" href="/css/{{ file }}.css" />
+      <link rel="stylesheet" href="{{ '/css/' | append: file | append: '.css' | cacheBust }}" />
     {%- endfor -%}
     {%- if layout != "theme-editor.html" -%}
-      <link rel="stylesheet" href="/css/theme.css" />
+      <link rel="stylesheet" href="{{ '/css/theme.css' | cacheBust }}" />
     {%- endif -%}
   {%- endif -%}
 

--- a/src/_lib/cache-buster.js
+++ b/src/_lib/cache-buster.js
@@ -1,0 +1,13 @@
+const BUILD_TIMESTAMP = Math.floor(Date.now() / 1000);
+
+export function configureCacheBuster(eleventyConfig) {
+	eleventyConfig.addFilter("cacheBust", function (url) {
+		const isProduction = process.env.ELEVENTY_ENV === "production";
+
+		if (!isProduction) {
+			return url;
+		}
+
+		return `${url}?cached=${BUILD_TIMESTAMP}`;
+	});
+}


### PR DESCRIPTION
## Summary
- Introduces a cache-busting mechanism for CSS assets in production builds
- Adds a new `cacheBust` filter that appends a build timestamp query parameter
- Updates stylesheet references in HTML templates to use the new cache-busting filter

## Changes

### Core Functionality
- Created `src/_lib/cache-buster.js` with the `configureCacheBuster` function
- Registers `cacheBust` filter in `.eleventy.js` for use in templates
- Filter only appends query parameter in production environment (`ELEVENTY_ENV=production`)

### Template Updates
- Modified `src/_includes/head.html` to apply `cacheBust` filter to all stylesheet URLs
  - Ensures updated CSS files bypass browser cache on new deploys

## Test plan
- [x] Built site locally and verified stylesheets' URLs include cache-busting query parameter when in production
- [x] Confirmed no query parameter added in non-production environment
- [x] Verified styles render correctly with updated URLs
- [x] Checked Eleventy build logs for correct plugin loading and filter registration

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d7085ef7-59d8-42d3-9695-2ed0c3e638e2