### PR TITLE
Fix feature section rendering when features list is empty

### DIFF
--- a/src/_layouts/item.html
+++ b/src/_layouts/item.html
@@ -94,7 +94,7 @@ layout: base
     {% include "map-embed.html" %}
   {%- endif -%}
 
-  {%- if features -%}
+  {%- if features and features.size > 0 -%}
     <hr>
     <h2>Features</h2>
     <ul class="product-features">


### PR DESCRIPTION
## Summary
- Prevents rendering the "Features" section header and list when the `features` collection is empty
- Enhances template condition to explicitly check that `features` exist and contain items before rendering

## Changes

### Template Update
- Modified `src/_layouts/item.html` to change the conditional from `{% if features %}` to `{% if features and features.size > 0 %}`
- Ensures cleaner UI by avoiding empty section display on items without features

## Test plan
- [x] Verified that items with non-empty `features` render the "Features" section properly
- [x] Confirmed that items without `features` or with empty `features` do not display the section or its `<hr>` divider
- [x] Checked that no template errors occur due to the new condition

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/2b0eba91-ef7d-44ac-a704-63e94246b366