### PR TITLE
Fix cache busting condition for production builds

### DIFF
--- a/src/_lib/cache-buster.js
+++ b/src/_lib/cache-buster.js
@@ -2,7 +2,7 @@ const BUILD_TIMESTAMP = Math.floor(Date.now() / 1000);
 
 export function configureCacheBuster(eleventyConfig) {
 	eleventyConfig.addFilter("cacheBust", function (url) {
-		const isProduction = process.env.ELEVENTY_ENV === "production";
+		const isProduction = process.env.ELEVENTY_RUN_MODE === "build";
 
 		if (!isProduction) {
 			return url;


### PR DESCRIPTION
## Summary
- Corrects the environment variable check used to determine production mode for cache busting
- Ensures cache busting filter runs only during build mode instead of relying on ELEVENTY_ENV

## Changes

### Core Functionality
- Updated `cacheBust` filter:
  - Changed environment variable from `ELEVENTY_ENV === "production"` to `ELEVENTY_RUN_MODE === "build"`
  - This accurately reflects the production build environment

## Test plan
- [x] Verified that URLs are cache busted only during build mode
- [x] Confirmed that non-build modes do not modify URLs
- [x] Checked that cache busting happens as expected in production deployments

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/dad28be3-ada2-41bf-8d9e-3c4d7034adc7